### PR TITLE
v0.0.3: bug fixes, comprehensive test suite, CI cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,19 +74,3 @@ jobs:
       - name: Run unit tests
         run: just test-unit
 
-  integration-tests:
-    needs: [build, build-wasm] 
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-        toolchain: [stable, nightly]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-just
-      - uses: ./.github/actions/setup-rust
-      - uses: foundry-rs/foundry-toolchain@v1
-      - name: Run integration tests
-        run: just test-integration
-        env:
-          CI_ENVIRONMENT: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: RUSTDOCFLAGS="-D warnings" cargo doc
   
   build:
-    needs: [clippy, cargo-fmt, cargo-doc] 
+    needs: [clippy, cargo-fmt, cargo-doc]
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -44,10 +44,10 @@ jobs:
       - run: just check
 
   build-wasm:
-    needs: [clippy, cargo-fmt, cargo-doc] 
+    needs: [clippy, cargo-fmt, cargo-doc]
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest]
         toolchain: [stable, nightly]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -60,10 +60,10 @@ jobs:
         run: just check-wasm
 
   unit-tests:
-    needs: [build, build-wasm] 
+    needs: [build, build-wasm]
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest]
         toolchain: [stable, nightly]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2025-11-07
+
+### Changed
+
+- Promote the builders and documentation to a stable 1.0.0 release with no API changes from 0.0.2.
+
 ## [0.0.2] - 2025-11-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2025-11-07
+## [0.0.3] - 2025-11-07
+
+### Fixed
+
+- Fix BIP-143 sighash bug: remove SegWit marker/flag from sighash preimage
+- Fix legacy sighash to use non-witness serialization
+- Fix `from_json` to handle contract creation (to: None)
+- Implement accessList parsing in `from_json`
 
 ### Changed
 
-- Promote the builders and documentation to a stable 1.0.0 release with no API changes from 0.0.2.
+- Add comprehensive test suite (70 → 100 unit tests) validated against Alloy and rust-bitcoin
+- Add doc comments across EVM types, signer module, and transaction builders
+- Fix clippy nursery lints
 
 ## [0.0.2] - 2025-11-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-rs"
-version = "1.0.0"
+version = "0.0.3"
 authors = ["Sig Network", "Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-rs"
-version = "0.0.2"
+version = "1.0.0"
 authors = ["Sig Network", "Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-signet-rs = "0.0.2"
+signet-rs = "1.0.0"
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-signet-rs = "1.0.0"
+signet-rs = "0.0.3"
 ```
 
 ## Features

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -140,7 +140,9 @@ impl BitcoinTransaction {
     pub fn build_for_signing_legacy(&self, sighash_type: EcdsaSighashType) -> Vec<u8> {
         let mut buffer = Vec::new();
 
-        let _ = self.encode(&mut buffer);
+        // Legacy sighash must use non-witness serialization regardless of
+        // whether any inputs already have witness data attached.
+        let _ = self.encode_without_witness(&mut buffer);
 
         // Sighash type
         buffer.extend_from_slice(&(sighash_type as u32).to_le_bytes());
@@ -227,13 +229,8 @@ impl BitcoinTransaction {
         // Version
         self.version.encode(buffer).unwrap();
 
-        let has_witness = self.input.iter().any(|input| !input.witness.is_empty());
-
-        if has_witness {
-            // Marker and Flag
-            buffer.push(SEGWIT_MARKER);
-            buffer.push(SEGWIT_FLAG);
-        }
+        // Note: BIP-143 sighash preimage must NOT include SegWit marker/flag.
+        // Those bytes are only for network serialization (BIP-144).
 
         // Hash prevouts
         let mut prevouts = Vec::new();
@@ -915,5 +912,1234 @@ mod tests {
 
         let result: Result<BitcoinTransaction, _> = serde_json::from_str(json_data);
         assert!(result.is_ok(), "Failed to deserialize: {:?}", result.err());
+    }
+
+    // ========================================================================
+    // SegWit Sighash Tests
+    // ========================================================================
+
+    #[test]
+    fn test_segwit_sighash_with_real_script_and_value() {
+        // P2PKH-style script code used for P2WPKH sighash:
+        // OP_DUP OP_HASH160 <20-byte-hash> OP_EQUALVERIFY OP_CHECKSIG
+        let script_hex = "76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+        let value_sats: u64 = 100_000_000; // 1 BTC
+
+        // Txid hex in display order (big-endian, as shown in block explorers).
+        // OmniHash stores bytes in this display order and reverses on encode.
+        // rust-bitcoin's from_byte_array takes the internal (little-endian) order,
+        // so we reverse the bytes for rust-bitcoin.
+        let txid_hex = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+        let txid_display_bytes = hex::decode(txid_hex).unwrap();
+        let mut display_arr = [0u8; 32];
+        display_arr.copy_from_slice(&txid_display_bytes);
+
+        // For rust-bitcoin: internal byte order = reversed display bytes
+        let mut internal_arr = display_arr;
+        internal_arr.reverse();
+
+        // rust-bitcoin reference
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(500_000).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array(internal_arr)),
+                    vout: 1,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(90_000_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let sighash_type = EcdsaSighashType::All;
+        let mut rb_buf: Vec<u8> = Vec::new();
+        SighashCache::new(&mut rb_tx)
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(value_sats),
+                sighash_type,
+            )
+            .unwrap();
+
+        // Our implementation
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(500_000).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash(display_arr)),
+                    vout: 1,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(90_000_000),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            0,
+            &OmniScriptBuf(script_bytes),
+            value_sats,
+        );
+
+        assert_eq!(rb_buf.len(), our_buf.len());
+        assert_eq!(rb_buf, our_buf);
+    }
+
+    #[test]
+    fn test_segwit_sighash_multiple_inputs() {
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+
+        let make_txid = |b: u8| -> [u8; 32] { [b; 32] };
+
+        let rb_inputs: Vec<RustBitcoinTxIn> = (0u8..3)
+            .map(|i| RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array(make_txid(i + 1))),
+                    vout: i as u32,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::default(),
+            })
+            .collect();
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: rb_inputs,
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let our_inputs: Vec<TxIn> = (0u8..3)
+            .map(|i| TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash(make_txid(i + 1))),
+                    vout: i as u32,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            })
+            .collect();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: our_inputs,
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(50_000),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let value = 100_000u64;
+        let sighash_type = EcdsaSighashType::All;
+
+        for input_index in 0..3 {
+            let mut rb_buf: Vec<u8> = Vec::new();
+            SighashCache::new(&mut rb_tx)
+                .segwit_v0_encode_signing_data_to(
+                    &mut rb_buf,
+                    input_index,
+                    &ScriptBuf::from_bytes(script_bytes.clone()),
+                    Amount::from_sat(value),
+                    sighash_type,
+                )
+                .unwrap();
+
+            let our_buf = our_tx.build_for_signing_segwit(
+                OmniSighashType::All,
+                input_index,
+                &OmniScriptBuf(script_bytes.clone()),
+                value,
+            );
+
+            assert_eq!(rb_buf, our_buf, "Mismatch at input index {input_index}");
+        }
+    }
+
+    #[test]
+    fn test_segwit_sighash_multiple_outputs() {
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+        // P2WPKH output script: OP_0 <20-byte-hash>
+        let p2wpkh_script = hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        // OP_RETURN data
+        let op_return_script = hex::decode("6a0b68656c6c6f20776f726c64").unwrap();
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(750_000).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xaa; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![
+                RustBitcoinTxOut {
+                    value: Amount::from_sat(50_000_000),
+                    script_pubkey: ScriptBuf::from_bytes(p2wpkh_script.clone()),
+                },
+                RustBitcoinTxOut {
+                    value: Amount::from_sat(49_000_000),
+                    script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+                },
+                RustBitcoinTxOut {
+                    value: Amount::from_sat(0),
+                    script_pubkey: ScriptBuf::from_bytes(op_return_script.clone()),
+                },
+            ],
+        };
+
+        let mut rb_buf: Vec<u8> = Vec::new();
+        SighashCache::new(&mut rb_tx)
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(100_000_000),
+                EcdsaSighashType::All,
+            )
+            .unwrap();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(750_000).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xaa; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![
+                TxOut {
+                    value: OmniAmount::from_sat(50_000_000),
+                    script_pubkey: OmniScriptBuf(p2wpkh_script),
+                },
+                TxOut {
+                    value: OmniAmount::from_sat(49_000_000),
+                    script_pubkey: OmniScriptBuf(script_bytes.clone()),
+                },
+                TxOut {
+                    value: OmniAmount::from_sat(0),
+                    script_pubkey: OmniScriptBuf(op_return_script),
+                },
+            ],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            0,
+            &OmniScriptBuf(script_bytes),
+            100_000_000,
+        );
+
+        assert_eq!(rb_buf, our_buf);
+    }
+
+    #[test]
+    fn test_segwit_sighash_large_value() {
+        // 21 million BTC in satoshis
+        let value_sats: u64 = 2_100_000_000_000_000;
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xff; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(value_sats),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let mut rb_buf: Vec<u8> = Vec::new();
+        SighashCache::new(&mut rb_tx)
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(value_sats),
+                EcdsaSighashType::All,
+            )
+            .unwrap();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xff; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(value_sats),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            0,
+            &OmniScriptBuf(script_bytes),
+            value_sats,
+        );
+
+        assert_eq!(rb_buf, our_buf);
+    }
+
+    #[test]
+    fn test_segwit_sighash_with_nondefault_sequence() {
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+        // RBF-enabled sequence
+        let rbf_sequence = 0xFFFF_FFFDu32;
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(100_000).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xbb; 32])),
+                    vout: 3,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence(rbf_sequence),
+                witness: Witness::default(),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(1_000_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let mut rb_buf: Vec<u8> = Vec::new();
+        SighashCache::new(&mut rb_tx)
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(2_000_000),
+                EcdsaSighashType::All,
+            )
+            .unwrap();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(100_000).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xbb; 32])),
+                    vout: 3,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence(rbf_sequence),
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(1_000_000),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            0,
+            &OmniScriptBuf(script_bytes),
+            2_000_000,
+        );
+
+        assert_eq!(rb_buf, our_buf);
+    }
+
+    // ========================================================================
+    // Transaction Serialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_segwit_serialization_against_rust_bitcoin() {
+        let script_bytes =
+            hex::decode("76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac").unwrap();
+        let witness_sig = vec![0x30; 71]; // mock DER sig
+        let witness_pubkey = vec![0x02; 33]; // mock compressed pubkey
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xab; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::from_slice(&[witness_sig.clone(), witness_pubkey.clone()]),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_serialized = bitcoin::consensus::serialize(&rb_tx);
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xab; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::from_slice(&[witness_sig, witness_pubkey]),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(50_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_serialized = our_tx.serialize();
+
+        assert_eq!(rb_serialized, our_serialized);
+    }
+
+    #[test]
+    fn test_segwit_serialization_multiple_witnesses() {
+        let script_bytes =
+            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+
+        let wit1_sig = vec![0x30; 72];
+        let wit1_pk = vec![0x03; 33];
+        let wit2_sig = vec![0x30; 71];
+        let wit2_pk = vec![0x02; 33];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(200_000).unwrap(),
+            input: vec![
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0x11; 32])),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&[wit1_sig.clone(), wit1_pk.clone()]),
+                },
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0x22; 32])),
+                        vout: 1,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&[wit2_sig.clone(), wit2_pk.clone()]),
+                },
+            ],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(80_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_serialized = bitcoin::consensus::serialize(&rb_tx);
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(200_000).unwrap(),
+            input: vec![
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0x11; 32])),
+                        vout: 0,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&[wit1_sig, wit1_pk]),
+                },
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0x22; 32])),
+                        vout: 1,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&[wit2_sig, wit2_pk]),
+                },
+            ],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(80_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_serialized = our_tx.serialize();
+
+        assert_eq!(rb_serialized, our_serialized);
+    }
+
+    #[test]
+    fn test_segwit_serialization_mixed_witness_empty() {
+        let script_bytes =
+            hex::decode("76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac").unwrap();
+
+        let wit_sig = vec![0x30; 70];
+        let wit_pk = vec![0x02; 33];
+
+        // First input has witness, second has empty witness
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0xcc; 32])),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&[wit_sig.clone(), wit_pk.clone()]),
+                },
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0xdd; 32])),
+                        vout: 1,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::default(),
+                },
+            ],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(30_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_serialized = bitcoin::consensus::serialize(&rb_tx);
+
+        // Verify segwit flag is present (byte at index 4 = 0x00 marker, index 5 = 0x01 flag)
+        assert_eq!(rb_serialized[4], 0x00, "Missing segwit marker");
+        assert_eq!(rb_serialized[5], 0x01, "Missing segwit flag");
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0xcc; 32])),
+                        vout: 0,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&[wit_sig, wit_pk]),
+                },
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0xdd; 32])),
+                        vout: 1,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::default(),
+                },
+            ],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(30_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_serialized = our_tx.serialize();
+
+        assert_eq!(rb_serialized, our_serialized);
+    }
+
+    // ========================================================================
+    // Txid Tests
+    // ========================================================================
+
+    #[test]
+    fn test_txid_segwit_multiple_inputs() {
+        let script_bytes =
+            hex::decode("76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac").unwrap();
+        let witness_data = vec![vec![0x30; 72], vec![0x02; 33]];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion::TWO,
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0x11; 32])),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&witness_data),
+                },
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(Hash::from_byte_array([0x22; 32])),
+                        vout: 1,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&witness_data),
+                },
+            ],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_txid = rb_tx.compute_txid();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0x11; 32])),
+                        vout: 0,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&witness_data),
+                },
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash([0x22; 32])),
+                        vout: 1,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&witness_data),
+                },
+            ],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(100_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_txid = our_tx.compute_txid();
+
+        assert_eq!(*rb_txid.as_byte_array(), our_txid.as_byte_array());
+        assert_eq!(rb_txid.to_string(), our_txid.to_string());
+    }
+
+    #[test]
+    fn test_txid_segwit_large_witness() {
+        let script_bytes =
+            hex::decode("76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac").unwrap();
+
+        // Large witness stack with 6 items
+        let large_witness: Vec<Vec<u8>> = vec![
+            vec![0x00],            // OP_0 for CHECKMULTISIG bug
+            vec![0x30; 72],        // sig 1
+            vec![0x30; 71],        // sig 2
+            vec![0x30; 70],        // sig 3
+            vec![0x30; 73],        // sig 4
+            vec![0x52; 105],       // redeem script
+        ];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion::TWO,
+            lock_time: RustBitcoinLockTime::from_height(300_000).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xee; 32])),
+                    vout: 2,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::from_slice(&large_witness),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(999_999),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_txid = rb_tx.compute_txid();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(300_000).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xee; 32])),
+                    vout: 2,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::from_slice(&large_witness),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(999_999),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_txid = our_tx.compute_txid();
+
+        assert_eq!(*rb_txid.as_byte_array(), our_txid.as_byte_array());
+        assert_eq!(rb_txid.to_string(), our_txid.to_string());
+    }
+
+    #[test]
+    fn test_txid_with_real_scripts() {
+        // P2WPKH output scripts: OP_0 <20-byte-hash>
+        let output_script_1 =
+            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        let output_script_2 =
+            hex::decode("0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+
+        let witness_data = vec![vec![0x30; 72], vec![0x02; 33]];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion::TWO,
+            lock_time: RustBitcoinLockTime::from_height(400_000).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0x55; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::from_slice(&witness_data),
+            }],
+            output: vec![
+                RustBitcoinTxOut {
+                    value: Amount::from_sat(40_000_000),
+                    script_pubkey: ScriptBuf::from_bytes(output_script_1.clone()),
+                },
+                RustBitcoinTxOut {
+                    value: Amount::from_sat(9_000_000),
+                    script_pubkey: ScriptBuf::from_bytes(output_script_2.clone()),
+                },
+            ],
+        };
+
+        let rb_txid = rb_tx.compute_txid();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(400_000).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0x55; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::from_slice(&witness_data),
+            }],
+            output: vec![
+                TxOut {
+                    value: OmniAmount::from_sat(40_000_000),
+                    script_pubkey: OmniScriptBuf(output_script_1),
+                },
+                TxOut {
+                    value: OmniAmount::from_sat(9_000_000),
+                    script_pubkey: OmniScriptBuf(output_script_2),
+                },
+            ],
+        };
+
+        let our_txid = our_tx.compute_txid();
+
+        assert_eq!(*rb_txid.as_byte_array(), our_txid.as_byte_array());
+        assert_eq!(rb_txid.to_string(), our_txid.to_string());
+    }
+
+    // ========================================================================
+    // Build With Witness Tests
+    // ========================================================================
+
+    #[test]
+    fn test_build_with_witness_p2wpkh() {
+        let script_bytes =
+            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        let witness_sig = vec![0x30; 72];
+        let witness_pubkey = vec![0x02; 33];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xaa; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::from_slice(&[witness_sig.clone(), witness_pubkey.clone()]),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_serialized = bitcoin::consensus::serialize(&rb_tx);
+
+        let mut our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xaa; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(50_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_serialized = our_tx.build_with_witness(
+            0,
+            vec![witness_sig, witness_pubkey],
+            TransactionType::P2WPKH,
+        );
+
+        assert_eq!(rb_serialized, our_serialized);
+    }
+
+    #[test]
+    fn test_build_with_witness_p2wsh() {
+        let script_bytes =
+            hex::decode("0020c015c4a6be010e21657068fc2e6a9d02b27ebe4d490a25846f7237f104d1a3cd")
+                .unwrap();
+
+        // P2WSH witness: OP_0, sig1, sig2, redeem_script (multisig)
+        let witness_items = vec![
+            vec![0x00],        // OP_0 for CHECKMULTISIG bug
+            vec![0x30; 72],    // signature 1
+            vec![0x30; 71],    // signature 2
+            vec![0x52; 71],    // redeem script (mock)
+        ];
+
+        let rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0xbb; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::from_slice(&witness_items),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(75_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let rb_serialized = bitcoin::consensus::serialize(&rb_tx);
+
+        let mut our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0xbb; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(75_000),
+                script_pubkey: OmniScriptBuf(script_bytes),
+            }],
+        };
+
+        let our_serialized = our_tx.build_with_witness(
+            0,
+            witness_items,
+            TransactionType::P2WSH,
+        );
+
+        assert_eq!(rb_serialized, our_serialized);
+    }
+
+    // ========================================================================
+    // Edge Case Tests
+    // ========================================================================
+
+    #[test]
+    fn test_segwit_locktime_time_based() {
+        // Time-based locktime: >= 500_000_000
+        let locktime_time = 500_000_100u32;
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_time(locktime_time).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array([0x44; 32])),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(5_000_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let mut rb_buf: Vec<u8> = Vec::new();
+        SighashCache::new(&mut rb_tx)
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(10_000_000),
+                EcdsaSighashType::All,
+            )
+            .unwrap();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_time(locktime_time).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash([0x44; 32])),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: OmniWitness::default(),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(5_000_000),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            0,
+            &OmniScriptBuf(script_bytes),
+            10_000_000,
+        );
+
+        assert_eq!(rb_buf, our_buf);
+    }
+
+    #[test]
+    fn test_segwit_multiple_inputs_different_values() {
+        let script_hex = "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+
+        let values = [50_000_000u64, 100_000_000, 200_000_000];
+
+        let make_txid = |b: u8| -> [u8; 32] { [b; 32] };
+
+        let rb_inputs: Vec<RustBitcoinTxIn> = (0u8..3)
+            .map(|i| RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::from_byte_array(make_txid(i + 0x10))),
+                    vout: i as u32,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::MAX,
+                witness: Witness::default(),
+            })
+            .collect();
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: rb_inputs,
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(340_000_000),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let our_inputs: Vec<TxIn> = (0u8..3)
+            .map(|i| TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash(make_txid(i + 0x10))),
+                    vout: i as u32,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::MAX,
+                witness: OmniWitness::default(),
+            })
+            .collect();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: our_inputs,
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(340_000_000),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let sighash_type = EcdsaSighashType::All;
+        let mut all_sighashes: Vec<Vec<u8>> = Vec::new();
+
+        for (input_index, &value) in values.iter().enumerate() {
+            let mut rb_buf: Vec<u8> = Vec::new();
+            SighashCache::new(&mut rb_tx)
+                .segwit_v0_encode_signing_data_to(
+                    &mut rb_buf,
+                    input_index,
+                    &ScriptBuf::from_bytes(script_bytes.clone()),
+                    Amount::from_sat(value),
+                    sighash_type,
+                )
+                .unwrap();
+
+            let our_buf = our_tx.build_for_signing_segwit(
+                OmniSighashType::All,
+                input_index,
+                &OmniScriptBuf(script_bytes.clone()),
+                value,
+            );
+
+            assert_eq!(rb_buf, our_buf, "Mismatch at input index {input_index}");
+            all_sighashes.push(our_buf);
+        }
+
+        // Verify each sighash is unique (different values produce different sighashes)
+        assert_ne!(all_sighashes[0], all_sighashes[1]);
+        assert_ne!(all_sighashes[1], all_sighashes[2]);
+        assert_ne!(all_sighashes[0], all_sighashes[2]);
+    }
+
+    // ========================================================================
+    // Regression tests for bugs found during spec audit
+    // ========================================================================
+
+    #[test]
+    fn test_segwit_sighash_with_prepopulated_witness() {
+        // Regression: encode_for_sighash_for_segwit must NOT include SegWit
+        // marker/flag bytes in the BIP-143 sighash preimage, even when some
+        // inputs already have witness data attached (e.g., signing input 1
+        // after input 0's witness was already set).
+        let script_hex = "76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac";
+        let script_bytes = hex::decode(script_hex).unwrap();
+        let value_sats: u64 = 50_000_000;
+
+        let txid_bytes = hex::decode(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        )
+        .unwrap();
+        let mut display_arr = [0u8; 32];
+        display_arr.copy_from_slice(&txid_bytes);
+        let mut internal_arr = display_arr;
+        internal_arr.reverse();
+
+        // Witness data that would already be on input 0
+        let existing_witness = vec![
+            vec![0x30; 70], // fake DER signature
+            vec![0x02; 33], // fake compressed pubkey
+        ];
+
+        // rust-bitcoin: input 0 has witness, we sign input 1
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(2),
+            lock_time: RustBitcoinLockTime::from_height(0).unwrap(),
+            input: vec![
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_byte_array(internal_arr),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::from_slice(&existing_witness),
+                },
+                RustBitcoinTxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_byte_array(internal_arr),
+                        vout: 1,
+                    },
+                    script_sig: ScriptBuf::default(),
+                    sequence: RustBitcoinSequence::MAX,
+                    witness: Witness::default(),
+                },
+            ],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(value_sats),
+                script_pubkey: ScriptBuf::from_bytes(script_bytes.clone()),
+            }],
+        };
+
+        let mut rb_buf: Vec<u8> = Vec::new();
+        let mut sighasher = SighashCache::new(&mut rb_tx);
+        sighasher
+            .segwit_v0_encode_signing_data_to(
+                &mut rb_buf,
+                1,
+                &ScriptBuf::from_bytes(script_bytes.clone()),
+                Amount::from_sat(value_sats),
+                EcdsaSighashType::All,
+            )
+            .unwrap();
+
+        // Our implementation: same tx with witness on input 0
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::Two,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash(display_arr)),
+                        vout: 0,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::from_slice(&existing_witness),
+                },
+                TxIn {
+                    previous_output: OmniOutPoint {
+                        txid: OmniTxid(OmniHash(display_arr)),
+                        vout: 1,
+                    },
+                    script_sig: OmniScriptBuf::default(),
+                    sequence: OmniSequence::MAX,
+                    witness: OmniWitness::default(),
+                },
+            ],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(value_sats),
+                script_pubkey: OmniScriptBuf(script_bytes.clone()),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_segwit(
+            OmniSighashType::All,
+            1,
+            &OmniScriptBuf(script_bytes),
+            value_sats,
+        );
+
+        assert_eq!(rb_buf, our_buf, "Sighash must match even when input 0 has witness data");
+    }
+
+    #[test]
+    fn test_legacy_sighash_with_witness_present() {
+        // Regression: build_for_signing_legacy must use non-witness serialization
+        // even when inputs have witness data attached.
+        let height = 1000000;
+
+        let witness_data = vec![vec![0x01, 0x02, 0x03]];
+
+        let mut rb_tx = RustBitcoinTransaction {
+            version: RustBitcoinVersion(1),
+            lock_time: RustBitcoinLockTime::from_height(height).unwrap(),
+            input: vec![RustBitcoinTxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(Hash::all_zeros()),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: RustBitcoinSequence::default(),
+                witness: Witness::from_slice(&witness_data),
+            }],
+            output: vec![RustBitcoinTxOut {
+                value: Amount::from_sat(10000),
+                script_pubkey: ScriptBuf::default(),
+            }],
+        };
+
+        let sighasher = SighashCache::new(&mut rb_tx);
+        let mut rb_buf: Vec<u8> = Vec::new();
+        sighasher
+            .legacy_encode_signing_data_to(
+                &mut rb_buf,
+                0,
+                &ScriptBuf::default(),
+                EcdsaSighashType::All.to_u32(),
+            )
+            .is_sighash_single_bug()
+            .unwrap();
+
+        let our_tx = OmniBitcoinTransaction {
+            version: Version::One,
+            lock_time: LockTime::from_height(height).unwrap(),
+            input: vec![TxIn {
+                previous_output: OmniOutPoint {
+                    txid: OmniTxid(OmniHash::all_zeros()),
+                    vout: 0,
+                },
+                script_sig: OmniScriptBuf::default(),
+                sequence: OmniSequence::default(),
+                witness: OmniWitness::from_slice(&witness_data),
+            }],
+            output: vec![TxOut {
+                value: OmniAmount::from_sat(10000),
+                script_pubkey: OmniScriptBuf::default(),
+            }],
+        };
+
+        let our_buf = our_tx.build_for_signing_legacy(OmniSighashType::All);
+
+        assert_eq!(rb_buf, our_buf, "Legacy sighash must exclude witness data");
     }
 }

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -1347,8 +1347,7 @@ mod tests {
 
     #[test]
     fn test_segwit_serialization_multiple_witnesses() {
-        let script_bytes =
-            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        let script_bytes = hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
 
         let wit1_sig = vec![0x30; 72];
         let wit1_pk = vec![0x03; 33];
@@ -1581,12 +1580,12 @@ mod tests {
 
         // Large witness stack with 6 items
         let large_witness: Vec<Vec<u8>> = vec![
-            vec![0x00],            // OP_0 for CHECKMULTISIG bug
-            vec![0x30; 72],        // sig 1
-            vec![0x30; 71],        // sig 2
-            vec![0x30; 70],        // sig 3
-            vec![0x30; 73],        // sig 4
-            vec![0x52; 105],       // redeem script
+            vec![0x00],      // OP_0 for CHECKMULTISIG bug
+            vec![0x30; 72],  // sig 1
+            vec![0x30; 71],  // sig 2
+            vec![0x30; 70],  // sig 3
+            vec![0x30; 73],  // sig 4
+            vec![0x52; 105], // redeem script
         ];
 
         let rb_tx = RustBitcoinTransaction {
@@ -1636,10 +1635,8 @@ mod tests {
     #[test]
     fn test_txid_with_real_scripts() {
         // P2WPKH output scripts: OP_0 <20-byte-hash>
-        let output_script_1 =
-            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
-        let output_script_2 =
-            hex::decode("0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+        let output_script_1 = hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        let output_script_2 = hex::decode("0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
 
         let witness_data = vec![vec![0x30; 72], vec![0x02; 33]];
 
@@ -1705,8 +1702,7 @@ mod tests {
 
     #[test]
     fn test_build_with_witness_p2wpkh() {
-        let script_bytes =
-            hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
+        let script_bytes = hex::decode("001489abcdefabbaabbaabbaabbaabbaabbaabbaabba").unwrap();
         let witness_sig = vec![0x30; 72];
         let witness_pubkey = vec![0x02; 33];
 
@@ -1765,10 +1761,10 @@ mod tests {
 
         // P2WSH witness: OP_0, sig1, sig2, redeem_script (multisig)
         let witness_items = vec![
-            vec![0x00],        // OP_0 for CHECKMULTISIG bug
-            vec![0x30; 72],    // signature 1
-            vec![0x30; 71],    // signature 2
-            vec![0x52; 71],    // redeem script (mock)
+            vec![0x00],     // OP_0 for CHECKMULTISIG bug
+            vec![0x30; 72], // signature 1
+            vec![0x30; 71], // signature 2
+            vec![0x52; 71], // redeem script (mock)
         ];
 
         let rb_tx = RustBitcoinTransaction {
@@ -1809,11 +1805,7 @@ mod tests {
             }],
         };
 
-        let our_serialized = our_tx.build_with_witness(
-            0,
-            witness_items,
-            TransactionType::P2WSH,
-        );
+        let our_serialized = our_tx.build_with_witness(0, witness_items, TransactionType::P2WSH);
 
         assert_eq!(rb_serialized, our_serialized);
     }
@@ -1985,10 +1977,9 @@ mod tests {
         let script_bytes = hex::decode(script_hex).unwrap();
         let value_sats: u64 = 50_000_000;
 
-        let txid_bytes = hex::decode(
-            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        )
-        .unwrap();
+        let txid_bytes =
+            hex::decode("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+                .unwrap();
         let mut display_arr = [0u8; 32];
         display_arr.copy_from_slice(&txid_bytes);
         let mut internal_arr = display_arr;
@@ -2079,7 +2070,10 @@ mod tests {
             value_sats,
         );
 
-        assert_eq!(rb_buf, our_buf, "Sighash must match even when input 0 has witness data");
+        assert_eq!(
+            rb_buf, our_buf,
+            "Sighash must match even when input 0 has witness data"
+        );
     }
 
     #[test]

--- a/src/bitcoin/encoding/io.rs
+++ b/src/bitcoin/encoding/io.rs
@@ -22,10 +22,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::UnexpectedEof => write!(f, "unexpected end of file"),
-            Error::InvalidData(msg) => write!(f, "invalid data: {}", msg),
-            Error::NonMinimalVarInt => write!(f, "non-minimal varint"),
-            Error::OversizedVectorAllocation => write!(f, "oversized vector allocation"),
+            Self::UnexpectedEof => write!(f, "unexpected end of file"),
+            Self::InvalidData(msg) => write!(f, "invalid data: {}", msg),
+            Self::NonMinimalVarInt => write!(f, "non-minimal varint"),
+            Self::OversizedVectorAllocation => write!(f, "oversized vector allocation"),
         }
     }
 }

--- a/src/bitcoin/psbt/serialize.rs
+++ b/src/bitcoin/psbt/serialize.rs
@@ -25,8 +25,8 @@ pub enum PsbtSerializeError {
 impl fmt::Display for PsbtSerializeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PsbtSerializeError::Io(s) => write!(f, "IO error: {}", s),
-            PsbtSerializeError::InvalidFormat(s) => write!(f, "Invalid format: {}", s),
+            Self::Io(s) => write!(f, "IO error: {}", s),
+            Self::InvalidFormat(s) => write!(f, "Invalid format: {}", s),
         }
     }
 }
@@ -45,16 +45,16 @@ pub enum PsbtParseError {
 impl fmt::Display for PsbtParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PsbtParseError::InvalidMagic => write!(f, "Invalid PSBT magic bytes"),
-            PsbtParseError::Io(s) => write!(f, "IO error: {}", s),
-            PsbtParseError::InvalidFormat(s) => write!(f, "Invalid format: {}", s),
+            Self::InvalidMagic => write!(f, "Invalid PSBT magic bytes"),
+            Self::Io(s) => write!(f, "IO error: {}", s),
+            Self::InvalidFormat(s) => write!(f, "Invalid format: {}", s),
         }
     }
 }
 
 impl From<IoError> for PsbtSerializeError {
     fn from(e: IoError) -> Self {
-        PsbtSerializeError::Io(alloc::format!("{}", e))
+        Self::Io(alloc::format!("{}", e))
     }
 }
 
@@ -403,7 +403,7 @@ mod tests {
         };
 
         // Create rust-bitcoin PSBT
-        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx.clone()).unwrap();
+        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx).unwrap();
 
         // Serialize rust-bitcoin PSBT
         let rb_serialized = rb_psbt.serialize();
@@ -468,7 +468,7 @@ mod tests {
             ],
         };
 
-        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx.clone()).unwrap();
+        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx).unwrap();
         let rb_serialized = rb_psbt.serialize();
 
         // Create our transaction (matching rust-bitcoin)
@@ -538,7 +538,7 @@ mod tests {
             }],
         };
 
-        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx.clone()).unwrap();
+        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx).unwrap();
         let rb_serialized = rb_psbt.serialize();
 
         // Create our transaction (matching rust-bitcoin)
@@ -596,7 +596,7 @@ mod tests {
             }],
         };
 
-        let mut rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx.clone()).unwrap();
+        let mut rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx).unwrap();
 
         rb_psbt.inputs[0].witness_utxo = Some(RustBitcoinTxOut {
             value: RustBitcoinAmount::from_sat(500_000_000),
@@ -672,7 +672,7 @@ mod tests {
             }],
         };
 
-        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx.clone()).unwrap();
+        let rb_psbt = RustBitcoinPsbt::from_unsigned_tx(rb_tx).unwrap();
         let rb_serialized = rb_psbt.serialize();
 
         // Create our transaction (matching rust-bitcoin)

--- a/src/bitcoin/types/tx_in/witness.rs
+++ b/src/bitcoin/types/tx_in/witness.rs
@@ -69,7 +69,7 @@ impl Witness {
     }
 
     /// Returns a struct implementing [`Iterator`].
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             inner: self.content.as_slice(),
             indices_start: self.indices_start,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,2 +1,2 @@
-/// EIP-1559 transaction type
+/// Typed transaction prefix for EIP-1559 payloads (0x02).
 pub const EIP_1559_TYPE: u8 = 0x02;

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -41,6 +41,7 @@ use alloc::{string::ToString, vec, vec::Vec};
 /// };
 /// ```
 ///
+/// Signing-ready EIP-1559 transaction produced by the builder or JSON parser.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EVMTransaction {
     #[serde(deserialize_with = "deserialize_u64")]
@@ -62,6 +63,7 @@ pub struct EVMTransaction {
 }
 
 impl EVMTransaction {
+    /// RLP-encode the EIP-1559 payload prefixed with transaction type (0x02) for signing.
     pub fn build_for_signing(&self) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -76,6 +78,7 @@ impl EVMTransaction {
         rlp_stream.out().to_vec()
     }
 
+    /// RLP-encode the transaction including `v`, `r`, `s` to broadcast to an RPC node.
     pub fn build_with_signature(&self, signature: &Signature) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -127,6 +130,7 @@ impl EVMTransaction {
         }
     }
 
+    /// Build an [`EVMTransaction`] from RPC-style JSON (hex strings for numeric fields).
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let v: serde_json::Value = serde_json::from_str(json)?;
 

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -41,7 +41,6 @@ use alloc::{string::ToString, vec, vec::Vec};
 /// };
 /// ```
 ///
-/// Signing-ready EIP-1559 transaction produced by the builder or JSON parser.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EVMTransaction {
     #[serde(deserialize_with = "deserialize_u64")]
@@ -63,7 +62,6 @@ pub struct EVMTransaction {
 }
 
 impl EVMTransaction {
-    /// RLP-encode the EIP-1559 payload prefixed with transaction type (0x02) for signing.
     pub fn build_for_signing(&self) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -78,7 +76,6 @@ impl EVMTransaction {
         rlp_stream.out().to_vec()
     }
 
-    /// RLP-encode the transaction including `v`, `r`, `s` to broadcast to an RPC node.
     pub fn build_with_signature(&self, signature: &Signature) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -130,16 +127,15 @@ impl EVMTransaction {
         }
     }
 
-    /// Build an [`EVMTransaction`] from RPC-style JSON (hex strings for numeric fields).
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let v: serde_json::Value = serde_json::from_str(json)?;
 
-        let to = v["to"].as_str().unwrap_or_default().to_string();
-
-        let to_parsed = parse_eth_address(
-            to.strip_prefix("0x")
-                .unwrap_or("0000000000000000000000000000000000000000"),
-        );
+        let to_parsed = match v["to"].as_str() {
+            Some(s) if !s.is_empty() && s != "0x" => {
+                Some(parse_eth_address(s.strip_prefix("0x").unwrap_or(s)))
+            }
+            _ => None,
+        };
 
         let nonce_str = v["nonce"].as_str().expect("nonce should be provided");
         let nonce = parse_u64(nonce_str).expect("nonce should be a valid u64");
@@ -169,19 +165,49 @@ impl EVMTransaction {
         let input =
             hex::decode(input.strip_prefix("0x").unwrap_or("")).expect("input should be hex");
 
-        // TODO: Implement access list
-        // let access_list = v["accessList"].as_str().unwrap_or_default().to_string();
+        let access_list = v["accessList"]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| {
+                        let addr_str = entry["address"].as_str()?;
+                        let addr = parse_eth_address(
+                            addr_str.strip_prefix("0x").unwrap_or(addr_str),
+                        );
+                        let keys = entry["storageKeys"]
+                            .as_array()
+                            .map(|keys| {
+                                keys.iter()
+                                    .filter_map(|k| {
+                                        let s = k.as_str()?;
+                                        let bytes = hex::decode(
+                                            s.strip_prefix("0x").unwrap_or(s),
+                                        )
+                                        .ok()?;
+                                        let mut key = [0u8; 32];
+                                        key.copy_from_slice(&bytes);
+                                        Some(key)
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        Some((addr, keys))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         Ok(Self {
             chain_id,
             nonce,
-            to: Some(to_parsed),
+            to: to_parsed,
             value,
             input,
             gas_limit,
             max_fee_per_gas,
             max_priority_fee_per_gas,
-            access_list: vec![],
+            access_list,
         })
     }
 }
@@ -341,7 +367,7 @@ mod tests {
         primitives::{address, hex, Address, Bytes, U256},
         rpc::types::{AccessList, TransactionRequest},
     };
-    use alloy_primitives::{b256, Signature};
+    use alloy_primitives::{b256, Signature, TxKind};
 
     use crate::evm::types::Signature as OmniSignature;
     use crate::evm::{evm_transaction::EVMTransaction, utils::parse_eth_address};
@@ -663,5 +689,627 @@ mod tests {
             result.is_ok(),
             "Expected deserialization to work with array of numbers"
         );
+    }
+
+    #[test]
+    fn test_build_for_signing_high_nonce() {
+        let nonce: u64 = u64::MAX - 1;
+        let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let chain_id = 1u64;
+        let value = 1_000_000_000_000_000u128; // 0.001 ETH
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit: GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(to)
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+            .with_gas_limit(GAS_LIMIT)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_large_value() {
+        // 100_000 ETH in wei = 100_000 * 10^18
+        let value: u128 = 100_000 * 1_000_000_000_000_000_000u128;
+        let nonce: u64 = 5;
+        let chain_id = 1u64;
+        let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit: GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(to)
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+            .with_gas_limit(GAS_LIMIT)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_zero_value() {
+        let nonce: u64 = 10;
+        let chain_id = 1u64;
+        let value = 0u128;
+        let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit: GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(to)
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+            .with_gas_limit(GAS_LIMIT)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_different_chain_ids() {
+        let chains: &[(u64, &str)] = &[
+            (137, "Polygon"),
+            (42161, "Arbitrum"),
+            (10, "Optimism"),
+        ];
+        let nonce: u64 = 0;
+        let value = 1_000_000_000_000_000u128;
+        let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        for &(chain_id, label) in chains {
+            let tx = EVMTransaction {
+                chain_id,
+                nonce,
+                to: to_address,
+                value,
+                input: vec![],
+                gas_limit: GAS_LIMIT,
+                max_fee_per_gas: MAX_FEE_PER_GAS,
+                max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+                access_list: vec![],
+            };
+
+            let rlp_bytes = tx.build_for_signing();
+
+            let alloy_tx = TransactionRequest::default()
+                .with_chain_id(chain_id)
+                .with_nonce(nonce)
+                .with_to(to)
+                .with_value(U256::from(value))
+                .with_max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
+                .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+                .with_gas_limit(GAS_LIMIT)
+                .with_input(vec![]);
+
+            let alloy_unsigned = alloy_tx
+                .build_unsigned()
+                .expect("Failed to build unsigned transaction");
+            let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+            let mut buf = vec![];
+            rlp_encoded.encode_for_signing(&mut buf);
+
+            assert_eq!(buf, rlp_bytes, "Mismatch for chain {label} (id={chain_id})");
+        }
+    }
+
+    #[test]
+    fn test_build_for_signing_high_gas_values() {
+        let max_fee_per_gas: u128 = 500_000_000_000; // 500 gwei
+        let max_priority_fee_per_gas: u128 = 50_000_000_000; // 50 gwei
+        let gas_limit: u128 = 1_000_000;
+        let nonce: u64 = 1;
+        let chain_id = 1u64;
+        let value = 0u128;
+        let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(to)
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(max_priority_fee_per_gas)
+            .with_max_fee_per_gas(max_fee_per_gas)
+            .with_gas_limit(gas_limit)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_with_access_list() {
+        use alloy::rpc::types::AccessListItem;
+
+        let chain_id = 1u64;
+        let nonce: u64 = 3;
+        let value = 0u128;
+        let gas_limit: u128 = 100_000;
+        let max_fee_per_gas: u128 = 30_000_000_000;
+        let max_priority_fee_per_gas: u128 = 2_000_000_000;
+        let to_address_bytes = parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+        let storage_key_1 = [0x01u8; 32];
+        let storage_key_2 = [0xffu8; 32];
+
+        // Our access list format: Vec<(Address, Vec<[u8; 32]>)>
+        let our_access_list: crate::evm::types::AccessList = vec![
+            (to_address_bytes, vec![storage_key_1, storage_key_2]),
+        ];
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: Some(to_address_bytes),
+            value,
+            input: vec![],
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: our_access_list,
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        // Build alloy TxEip1559 directly for access list support
+        let alloy_access_list = AccessList(vec![AccessListItem {
+            address: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+            storage_keys: vec![
+                storage_key_1.into(),
+                storage_key_2.into(),
+            ],
+        }]);
+
+        let alloy_tx = TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            to: TxKind::Call(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+            value: U256::from(value),
+            input: Bytes::new(),
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: alloy_access_list,
+        };
+
+        let mut buf = vec![];
+        alloy_tx.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_with_multiple_access_list_entries() {
+        use alloy::rpc::types::AccessListItem;
+
+        let chain_id = 1u64;
+        let nonce: u64 = 7;
+        let value = 0u128;
+        let gas_limit: u128 = 200_000;
+        let max_fee_per_gas: u128 = 25_000_000_000;
+        let max_priority_fee_per_gas: u128 = 1_500_000_000;
+
+        let addr1_bytes = parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let addr2_bytes = parse_eth_address("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6");
+
+        let sk1 = [0xaau8; 32];
+        let sk2 = [0xbbu8; 32];
+        let sk3 = [0xccu8; 32];
+
+        let our_access_list: crate::evm::types::AccessList = vec![
+            (addr1_bytes, vec![sk1, sk2]),
+            (addr2_bytes, vec![sk3]),
+        ];
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: Some(addr1_bytes),
+            value,
+            input: vec![],
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: our_access_list,
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_access_list = AccessList(vec![
+            AccessListItem {
+                address: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+                storage_keys: vec![sk1.into(), sk2.into()],
+            },
+            AccessListItem {
+                address: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6"),
+                storage_keys: vec![sk3.into()],
+            },
+        ]);
+
+        let alloy_tx = TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            to: TxKind::Call(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+            value: U256::from(value),
+            input: Bytes::new(),
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: alloy_access_list,
+        };
+
+        let mut buf = vec![];
+        alloy_tx.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_for_signing_contract_creation() {
+        let chain_id = 1u64;
+        let nonce: u64 = 0;
+        let value = 0u128;
+        let gas_limit: u128 = 3_000_000;
+        let max_fee_per_gas: u128 = 20_000_000_000;
+        let max_priority_fee_per_gas: u128 = 1_000_000_000;
+        // Simple contract bytecode (just STOP opcode)
+        let input = vec![0x60, 0x00, 0x60, 0x00, 0x52, 0x60, 0x01, 0x60, 0x00, 0xf3];
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: None,
+            value,
+            input: input.clone(),
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            to: TxKind::Create,
+            value: U256::from(value),
+            input: Bytes::from(input),
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: AccessList::default(),
+        };
+
+        let mut buf = vec![];
+        alloy_tx.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_build_with_signature_different_parity() {
+        let chain_id = 1u64;
+        let nonce: u64 = 0x10;
+        let gas_limit: u128 = 21_000;
+        let value = 1_000_000_000_000_000u128;
+        let max_fee_per_gas: u128 = 20_000_000_000;
+        let max_priority_fee_per_gas: u128 = 1_000_000_000;
+
+        let to_str = "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+        let to_address = Some(parse_eth_address(to_str));
+
+        let tx_omni = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: vec![],
+        };
+
+        let alloy_tx = TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            to: TxKind::Call(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+            value: U256::from(value),
+            input: Bytes::new(),
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: AccessList::default(),
+        };
+
+        // v=1 (odd parity)
+        let sig = Signature::from_scalars_and_parity(
+            b256!("840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565"),
+            b256!("25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1"),
+            true,
+        )
+        .unwrap();
+
+        let mut alloy_encoded: Vec<u8> = vec![];
+        alloy_tx.encode_with_signature(&sig, &mut alloy_encoded, false);
+
+        let omni_sig = OmniSignature {
+            v: sig.v().to_u64(),
+            r: sig.r().to_be_bytes::<32>().to_vec(),
+            s: sig.s().to_be_bytes::<32>().to_vec(),
+        };
+
+        let omni_encoded = tx_omni.build_with_signature(&omni_sig);
+
+        assert_eq!(alloy_encoded, omni_encoded);
+    }
+
+    #[test]
+    fn test_build_for_signing_sepolia() {
+        let chain_id = 11155111u64;
+        let nonce: u64 = 42;
+        let value = 50_000_000_000_000_000u128; // 0.05 ETH
+        let gas_limit: u128 = 21_000;
+        let max_fee_per_gas: u128 = 10_000_000_000; // 10 gwei
+        let max_priority_fee_per_gas: u128 = 1_500_000_000; // 1.5 gwei
+
+        let to: Address = address!("525521d79134822a342d330bd91DA67976569aF1");
+        let to_address = Some(parse_eth_address("525521d79134822a342d330bd91DA67976569aF1"));
+
+        let tx = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            access_list: vec![],
+        };
+
+        let rlp_bytes = tx.build_for_signing();
+
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(to)
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(max_priority_fee_per_gas)
+            .with_max_fee_per_gas(max_fee_per_gas)
+            .with_gas_limit(gas_limit)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_bytes);
+    }
+
+    #[test]
+    fn test_from_json_contract_creation() {
+        let json = r#"
+        {
+            "to": "0x",
+            "nonce": "0",
+            "value": "0",
+            "maxPriorityFeePerGas": "0x1",
+            "maxFeePerGas": "0x1",
+            "gasLimit": "3000000",
+            "chainId": "1",
+            "input": "0x6000"
+        }"#;
+
+        let tx = EVMTransaction::from_json(json).unwrap();
+        assert_eq!(tx.to, None);
+        assert_eq!(tx.input, vec![0x60, 0x00]);
+        assert_eq!(tx.gas_limit, 3_000_000);
+    }
+
+    #[test]
+    fn test_from_json_with_access_list() {
+        let json = r#"
+        {
+            "to": "0x525521d79134822a342d330bd91DA67976569aF1",
+            "nonce": "1",
+            "value": "0",
+            "maxPriorityFeePerGas": "0x3b9aca00",
+            "maxFeePerGas": "0x4a817c800",
+            "gasLimit": "100000",
+            "chainId": "1",
+            "input": "0x",
+            "accessList": [
+                {
+                    "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                    "storageKeys": [
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    ]
+                }
+            ]
+        }"#;
+
+        let tx = EVMTransaction::from_json(json).unwrap();
+
+        assert_eq!(tx.access_list.len(), 1);
+        assert_eq!(
+            tx.access_list[0].0,
+            parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+        );
+        assert_eq!(tx.access_list[0].1.len(), 1);
+        let mut expected_key = [0u8; 32];
+        expected_key[31] = 1;
+        assert_eq!(tx.access_list[0].1[0], expected_key);
+
+        assert_eq!(tx.chain_id, 1);
+        assert_eq!(tx.nonce, 1);
+        assert_eq!(tx.value, 0);
+        assert_eq!(tx.gas_limit, 100_000);
+        assert_eq!(tx.max_priority_fee_per_gas, 1_000_000_000);
+        assert_eq!(tx.max_fee_per_gas, 20_000_000_000);
+    }
+
+    #[test]
+    fn test_build_for_signing_empty_input_vs_no_input() {
+        let chain_id = 1u64;
+        let nonce: u64 = 0;
+        let value = 1_000_000_000_000_000u128;
+        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+
+        // Explicitly empty input
+        let tx_empty = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: vec![],
+            gas_limit: GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+            access_list: vec![],
+        };
+
+        // Also empty but via Vec::new()
+        let tx_new = EVMTransaction {
+            chain_id,
+            nonce,
+            to: to_address,
+            value,
+            input: Vec::new(),
+            gas_limit: GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+            access_list: vec![],
+        };
+
+        let rlp_empty = tx_empty.build_for_signing();
+        let rlp_new = tx_new.build_for_signing();
+
+        assert_eq!(rlp_empty, rlp_new);
+
+        // Also verify against Alloy
+        let alloy_tx = TransactionRequest::default()
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
+            .with_value(U256::from(value))
+            .with_max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+            .with_gas_limit(GAS_LIMIT)
+            .with_input(vec![]);
+
+        let alloy_unsigned = alloy_tx
+            .build_unsigned()
+            .expect("Failed to build unsigned transaction");
+        let rlp_encoded = alloy_unsigned.eip1559().unwrap();
+
+        let mut buf = vec![];
+        rlp_encoded.encode_for_signing(&mut buf);
+
+        assert_eq!(buf, rlp_empty);
     }
 }

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -172,19 +172,16 @@ impl EVMTransaction {
                     .iter()
                     .filter_map(|entry| {
                         let addr_str = entry["address"].as_str()?;
-                        let addr = parse_eth_address(
-                            addr_str.strip_prefix("0x").unwrap_or(addr_str),
-                        );
+                        let addr =
+                            parse_eth_address(addr_str.strip_prefix("0x").unwrap_or(addr_str));
                         let keys = entry["storageKeys"]
                             .as_array()
                             .map(|keys| {
                                 keys.iter()
                                     .filter_map(|k| {
                                         let s = k.as_str()?;
-                                        let bytes = hex::decode(
-                                            s.strip_prefix("0x").unwrap_or(s),
-                                        )
-                                        .ok()?;
+                                        let bytes =
+                                            hex::decode(s.strip_prefix("0x").unwrap_or(s)).ok()?;
                                         let mut key = [0u8; 32];
                                         key.copy_from_slice(&bytes);
                                         Some(key)
@@ -697,7 +694,9 @@ mod tests {
         let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
         let chain_id = 1u64;
         let value = 1_000_000_000_000_000u128; // 0.001 ETH
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         let tx = EVMTransaction {
             chain_id,
@@ -741,7 +740,9 @@ mod tests {
         let nonce: u64 = 5;
         let chain_id = 1u64;
         let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         let tx = EVMTransaction {
             chain_id,
@@ -784,7 +785,9 @@ mod tests {
         let chain_id = 1u64;
         let value = 0u128;
         let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         let tx = EVMTransaction {
             chain_id,
@@ -823,15 +826,13 @@ mod tests {
 
     #[test]
     fn test_build_for_signing_different_chain_ids() {
-        let chains: &[(u64, &str)] = &[
-            (137, "Polygon"),
-            (42161, "Arbitrum"),
-            (10, "Optimism"),
-        ];
+        let chains: &[(u64, &str)] = &[(137, "Polygon"), (42161, "Arbitrum"), (10, "Optimism")];
         let nonce: u64 = 0;
         let value = 1_000_000_000_000_000u128;
         let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         for &(chain_id, label) in chains {
             let tx = EVMTransaction {
@@ -879,7 +880,9 @@ mod tests {
         let chain_id = 1u64;
         let value = 0u128;
         let to: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         let tx = EVMTransaction {
             chain_id,
@@ -932,9 +935,8 @@ mod tests {
         let storage_key_2 = [0xffu8; 32];
 
         // Our access list format: Vec<(Address, Vec<[u8; 32]>)>
-        let our_access_list: crate::evm::types::AccessList = vec![
-            (to_address_bytes, vec![storage_key_1, storage_key_2]),
-        ];
+        let our_access_list: crate::evm::types::AccessList =
+            vec![(to_address_bytes, vec![storage_key_1, storage_key_2])];
 
         let tx = EVMTransaction {
             chain_id,
@@ -953,10 +955,7 @@ mod tests {
         // Build alloy TxEip1559 directly for access list support
         let alloy_access_list = AccessList(vec![AccessListItem {
             address: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
-            storage_keys: vec![
-                storage_key_1.into(),
-                storage_key_2.into(),
-            ],
+            storage_keys: vec![storage_key_1.into(), storage_key_2.into()],
         }]);
 
         let alloy_tx = TxEip1559 {
@@ -995,10 +994,8 @@ mod tests {
         let sk2 = [0xbbu8; 32];
         let sk3 = [0xccu8; 32];
 
-        let our_access_list: crate::evm::types::AccessList = vec![
-            (addr1_bytes, vec![sk1, sk2]),
-            (addr2_bytes, vec![sk3]),
-        ];
+        let our_access_list: crate::evm::types::AccessList =
+            vec![(addr1_bytes, vec![sk1, sk2]), (addr2_bytes, vec![sk3])];
 
         let tx = EVMTransaction {
             chain_id,
@@ -1154,7 +1151,9 @@ mod tests {
         let max_priority_fee_per_gas: u128 = 1_500_000_000; // 1.5 gwei
 
         let to: Address = address!("525521d79134822a342d330bd91DA67976569aF1");
-        let to_address = Some(parse_eth_address("525521d79134822a342d330bd91DA67976569aF1"));
+        let to_address = Some(parse_eth_address(
+            "525521d79134822a342d330bd91DA67976569aF1",
+        ));
 
         let tx = EVMTransaction {
             chain_id,
@@ -1258,7 +1257,9 @@ mod tests {
         let chain_id = 1u64;
         let nonce: u64 = 0;
         let value = 1_000_000_000_000_000u128;
-        let to_address = Some(parse_eth_address("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        let to_address = Some(parse_eth_address(
+            "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ));
 
         // Explicitly empty input
         let tx_empty = EVMTransaction {

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -137,33 +137,44 @@ impl EVMTransaction {
             _ => None,
         };
 
-        let nonce_str = v["nonce"].as_str().expect("nonce should be provided");
-        let nonce = parse_u64(nonce_str).expect("nonce should be a valid u64");
+        let err = |msg: &str| serde_json::Error::custom(alloc::string::String::from(msg));
 
-        let value_str = v["value"].as_str().expect("value should be provided");
-        let value = parse_u128(value_str).expect("value should be a valid u128");
+        let nonce_str = v["nonce"]
+            .as_str()
+            .ok_or_else(|| err("nonce should be provided"))?;
+        let nonce = parse_u64(nonce_str).map_err(|_| err("nonce should be a valid u64"))?;
 
-        let gas_limit_str = v["gasLimit"].as_str().expect("gasLimit should be provided");
-        let gas_limit = parse_u128(gas_limit_str).expect("gasLimit should be a valid u128");
+        let value_str = v["value"]
+            .as_str()
+            .ok_or_else(|| err("value should be provided"))?;
+        let value = parse_u128(value_str).map_err(|_| err("value should be a valid u128"))?;
+
+        let gas_limit_str = v["gasLimit"]
+            .as_str()
+            .ok_or_else(|| err("gasLimit should be provided"))?;
+        let gas_limit =
+            parse_u128(gas_limit_str).map_err(|_| err("gasLimit should be a valid u128"))?;
 
         let max_priority_fee_per_gas_str = v["maxPriorityFeePerGas"]
             .as_str()
-            .expect("maxPriorityFeePerGas should be provided");
+            .ok_or_else(|| err("maxPriorityFeePerGas should be provided"))?;
         let max_priority_fee_per_gas = parse_u128(max_priority_fee_per_gas_str)
-            .expect("maxPriorityFeePerGas should be a valid u128");
+            .map_err(|_| err("maxPriorityFeePerGas should be a valid u128"))?;
 
         let max_fee_per_gas_str = v["maxFeePerGas"]
             .as_str()
-            .expect("maxFeePerGas should be provided");
-        let max_fee_per_gas =
-            parse_u128(max_fee_per_gas_str).expect("maxFeePerGas should be a valid u128");
+            .ok_or_else(|| err("maxFeePerGas should be provided"))?;
+        let max_fee_per_gas = parse_u128(max_fee_per_gas_str)
+            .map_err(|_| err("maxFeePerGas should be a valid u128"))?;
 
-        let chain_id_str = v["chainId"].as_str().expect("chainId should be provided");
-        let chain_id = parse_u64(chain_id_str).expect("chainId should be a valid u64");
+        let chain_id_str = v["chainId"]
+            .as_str()
+            .ok_or_else(|| err("chainId should be provided"))?;
+        let chain_id = parse_u64(chain_id_str).map_err(|_| err("chainId should be a valid u64"))?;
 
         let input = v["input"].as_str().unwrap_or_default().to_string();
-        let input =
-            hex::decode(input.strip_prefix("0x").unwrap_or("")).expect("input should be hex");
+        let input = hex::decode(input.strip_prefix("0x").unwrap_or(""))
+            .map_err(|_| err("input should be valid hex"))?;
 
         let access_list = v["accessList"]
             .as_array()
@@ -250,6 +261,12 @@ where
                 let n = v
                     .as_u64()
                     .ok_or_else(|| DeError::invalid_type(Unexpected::Other("not a u64"), &"u8"))?;
+                if n > 255 {
+                    return Err(DeError::invalid_value(
+                        Unexpected::Unsigned(n),
+                        &"a value in 0..=255",
+                    ));
+                }
                 out[i] = n as u8;
             }
             return Ok(Some(out));
@@ -304,10 +321,13 @@ where
         }
 
         fn visit_str<E: DeError>(self, s: &str) -> Result<Self::Value, E> {
-            s.parse::<u64>().map_err(|_| {
-                use alloc::format;
-                DeError::custom(format!("invalid u64 string: {}", s))
-            })
+            s.strip_prefix("0x")
+                .map(|hex| u64::from_str_radix(hex, 16))
+                .unwrap_or_else(|| s.parse::<u64>())
+                .map_err(|_| {
+                    use alloc::format;
+                    DeError::custom(format!("invalid u64 string: {}", s))
+                })
         }
     }
 
@@ -336,10 +356,14 @@ where
         }
 
         fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
-            value.parse::<u128>().map_err(|_| {
-                use alloc::format;
-                DeError::custom(format!("invalid u128 string: {}", value))
-            })
+            value
+                .strip_prefix("0x")
+                .map(|hex| u128::from_str_radix(hex, 16))
+                .unwrap_or_else(|| value.parse::<u128>())
+                .map_err(|_| {
+                    use alloc::format;
+                    DeError::custom(format!("invalid u128 string: {}", value))
+                })
         }
     }
 

--- a/src/evm/types.rs
+++ b/src/evm/types.rs
@@ -2,10 +2,13 @@
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
+/// Raw 20-byte Ethereum address (no checksum casing).
 pub type Address = [u8; 20];
 
+/// Access list entries represented as `(address, storage_keys)` tuples.
 pub type AccessList = Vec<(Address, Vec<[u8; 32]>)>;
 
+/// EVM signature payload compatible with signing providers and RLP assembly.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Signature {
     pub v: u64,

--- a/src/evm/utils.rs
+++ b/src/evm/utils.rs
@@ -3,6 +3,7 @@ use hex;
 
 use super::types::Address;
 
+/// Parse a 40-character hex address (no `0x` prefix) into a fixed array, panic on invalid input.
 pub fn parse_eth_address(address: &str) -> Address {
     let address = hex::decode(address).expect("address should be hex");
     assert_eq!(address.len(), 20, "address should be 20 bytes long");

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -1,1 +1,3 @@
+//! Helper types for integrating with remote signing services.
+
 pub mod types;

--- a/src/signer/types.rs
+++ b/src/signer/types.rs
@@ -1,6 +1,8 @@
+//! Serializable payloads used by external signing backends.
 use alloc::string::String;
 use serde::{Deserialize, Serialize};
 
+/// Response returned by a remote signer that includes the full ECDSA signature parts.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SignatureResponse {
     pub big_r: SerializableAffinePoint,
@@ -8,16 +10,19 @@ pub struct SignatureResponse {
     pub recovery_id: u8,
 }
 
+/// Hex-encoded affine point (uncompressed) for the signature's R component.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SerializableAffinePoint {
     pub affine_point: String,
 }
 
+/// Hex-encoded scalar for the signature's S component.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SerializableScalar {
     pub scalar: String,
 }
 
+/// Request sent to a signing service describing what and where to sign.
 #[derive(Debug, Serialize)]
 pub struct SignRequest {
     pub payload: [u8; 32],

--- a/src/transaction_builders.rs
+++ b/src/transaction_builders.rs
@@ -6,7 +6,9 @@ use crate::bitcoin::BitcoinTransactionBuilder;
 use crate::evm::EVMTransactionBuilder;
 
 #[cfg(feature = "evm")]
+/// Convenience alias for the EVM transaction builder.
 pub type EVM = EVMTransactionBuilder;
 
 #[cfg(feature = "bitcoin")]
+/// Convenience alias for the Bitcoin transaction builder.
 pub type BITCOIN = BitcoinTransactionBuilder;


### PR DESCRIPTION
## Summary
- Bump version from 0.0.2 to 0.0.3 (patch release)
- **Fix critical BIP-143 sighash bug**: `encode_for_sighash_for_segwit` was inserting SegWit marker/flag bytes into the sighash preimage when inputs had witness data — violates BIP-143 spec and would produce invalid signatures in multi-input signing flows
- **Fix legacy sighash bug**: `build_for_signing_legacy` now uses non-witness serialization regardless of witness state
- **Fix `from_json` defects**: contract creation (`to: None`) now works, `accessList` is now parsed instead of silently discarded, returns `Result` errors instead of panicking
- **Fix `deserialize_address`**: reject values > 255 instead of silent truncation
- **Fix `deserialize_u64`/`deserialize_u128`**: support hex strings (`0x` prefix) in serde path
- **Add 30 new tests** (70 → 100 unit + 4 doc) validated byte-for-byte against Alloy (EVM) and rust-bitcoin (BTC) reference implementations
- Add doc comments across EVM types, signer module, transaction builders, and constants
- Fix clippy nursery lints
- **Simplify CI**: remove empty integration-tests job, drop macOS from WASM and unit-test matrices (15 → 11 jobs)

## Test plan
- [x] `cargo test --all-features` — 104 tests pass
- [x] `cargo clippy --all-targets -- -D clippy::all -D clippy::nursery` — clean
- [x] `cargo fmt --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- [x] CI pipeline passes