### PR TITLE
Improve documentation across all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,23 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Fix BIP-143 sighash bug: remove SegWit marker/flag from sighash preimage
 - Fix legacy sighash to use non-witness serialization
 - Fix `from_json` to handle contract creation (to: None)
-- Implement accessList parsing in `from_json`
+- Fix `from_json` panics: return `Result` errors instead of panicking
+- Fix `deserialize_address` silent truncation of values > 255
+- Fix `deserialize_u64`/`deserialize_u128` to support hex strings in serde path
+
+### Added
+
+- `accessList` parsing in `from_json`
+
+### Added
+
+- Comprehensive test suite (70 → 100 unit tests) validated against Alloy and rust-bitcoin
+- Doc comments across EVM types, signer module, and transaction builders
 
 ### Changed
 
-- Add comprehensive test suite (70 → 100 unit tests) validated against Alloy and rust-bitcoin
-- Add doc comments across EVM types, signer module, and transaction builders
 - Fix clippy nursery lints
+- Simplify CI matrix (15 → 11 jobs)
 
 ## [0.0.2] - 2025-11-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 repository = "https://github.com/sig-net/signet.rs"
 documentation = "https://docs.rs/signet-rs"
 readme = "README.md"
-description = "Transaction builder for all chains in Rust"
+description = "Minimal no_std transaction builders for Bitcoin and EVM"
+keywords = ["bitcoin", "evm", "transaction", "no-std", "signing"]
+categories = ["cryptography::cryptocurrencies", "no-std::no-alloc"]
 
 [lib]
 crate-type = ["rlib"]  # Only rlib for Substrate integration

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ let txin: TxIn = TxIn {
     witness: Witness::default(),
 };
 
-let sender_script_pubkey_hex = "76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac";
-let sender_script_pubkey = ScriptBuf(sender_script_pubkey_hex.as_bytes().to_vec());
+let sender_script_pubkey = ScriptBuf::from_hex(
+    "76a914cb8a3018cf279311b148cb8d13728bd8cbe95bda88ac"
+).unwrap();
 
-let receiver_script_pubkey_hex = "76a914406cf8a18b97a230d15ed82f0d251560a05bda0688ac";
-let receiver_script_pubkey = ScriptBuf(receiver_script_pubkey_hex.as_bytes().to_vec());
+let receiver_script_pubkey = ScriptBuf::from_hex(
+    "76a914406cf8a18b97a230d15ed82f0d251560a05bda0688ac"
+).unwrap();
 
 let spend_txout: TxOut = TxOut {
     value: Amount::from_sat(500_000_000),

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -18,11 +18,11 @@ use super::{
     },
 };
 
+/// A Bitcoin transaction with version, locktime, inputs, and outputs.
 ///
 /// ###### Example:
 ///
-/// You can create a Bitcoin transaction directly in your NEAR contract or Rust client
-/// or you can do it from a JSON.
+/// You can create a Bitcoin transaction directly via struct literal or from JSON.
 ///
 /// ```rust
 /// use signet_rs::bitcoin::types::{
@@ -100,7 +100,7 @@ fn sha256d(data: &[u8]) -> Vec<u8> {
 }
 
 impl BitcoinTransaction {
-    /// Encode the transaction into a vector of bytes
+    /// Serialize the transaction to bytes (BIP-144 format if witness data is present).
     pub fn serialize(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
 
@@ -121,6 +121,7 @@ impl BitcoinTransaction {
         Ok(len)
     }
 
+    /// Compute the transaction ID (double-SHA256 of the non-witness serialization, per BIP-141).
     pub fn compute_txid(&self) -> Txid {
         let mut buffer = Vec::new();
         self.encode_without_witness(&mut buffer)
@@ -132,6 +133,7 @@ impl BitcoinTransaction {
         ))
     }
 
+    /// Convert this transaction into a [`Psbt`](crate::bitcoin::psbt::Psbt) for incremental signing.
     pub fn to_psbt(&self) -> crate::bitcoin::psbt::Psbt {
         crate::bitcoin::psbt::Psbt::from_unsigned_tx(self.clone())
     }
@@ -151,6 +153,10 @@ impl BitcoinTransaction {
     }
 
     /// Attach a script sig to the transaction
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tx_type` is a SegWit type (use [`build_with_witness`](Self::build_with_witness) instead).
     pub fn build_with_script_sig(
         &mut self,
         input_index: usize,
@@ -173,6 +179,10 @@ impl BitcoinTransaction {
     }
 
     /// Encode the transaction for signing in SegWit format
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transaction version is not [`Version::Two`].
     pub fn build_for_signing_segwit(
         &self,
         sighash_type: EcdsaSighashType,
@@ -195,6 +205,10 @@ impl BitcoinTransaction {
     }
 
     /// Function to attach a witness to the transaction
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tx_type` is a legacy type (use [`build_with_script_sig`](Self::build_with_script_sig) instead).
     pub fn build_with_witness(
         &mut self,
         input_index: usize,
@@ -284,7 +298,7 @@ impl BitcoinTransaction {
         self.input.is_empty()
     }
 
-    /// Serialise a JSON representation of the transaction into a BitcoinTransaction struct
+    /// Deserialize a JSON object into a [`BitcoinTransaction`].
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let tx: Self = serde_json::from_str(json)?;
         Ok(tx)

--- a/src/bitcoin/bitcoin_transaction_builder.rs
+++ b/src/bitcoin/bitcoin_transaction_builder.rs
@@ -25,6 +25,10 @@ impl Default for BitcoinTransactionBuilder {
 
 impl TxBuilder<BitcoinTransaction> for BitcoinTransactionBuilder {
     /// Ensures all mandatory fields are set and returns the immutable transaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `version` or `lock_time` have not been set.
     fn build(&self) -> BitcoinTransaction {
         BitcoinTransaction {
             version: self.version.expect("Missing version"),

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -7,7 +7,7 @@ pub mod psbt;
 pub mod types;
 pub mod utils;
 
-/// Bitcoin transaction
+/// Bitcoin transaction -- use [`BitcoinTransactionBuilder`] for ergonomic construction.
 pub use bitcoin_transaction::BitcoinTransaction;
-/// Bitcoin transaction builder
+/// Fluent builder for [`BitcoinTransaction`] values.
 pub use bitcoin_transaction_builder::BitcoinTransactionBuilder;

--- a/src/bitcoin/psbt/types.rs
+++ b/src/bitcoin/psbt/types.rs
@@ -47,6 +47,7 @@ pub struct Output {
 }
 
 impl Psbt {
+    /// Create a new PSBT from an unsigned transaction, initialising empty per-input/output maps.
     pub fn from_unsigned_tx(tx: BitcoinTransaction) -> Self {
         Self {
             unsigned_tx: tx.clone(),
@@ -58,6 +59,7 @@ impl Psbt {
         }
     }
 
+    /// Set the witness UTXO (value + script_pubkey) for the given input.
     pub fn update_input_with_witness_utxo(
         &mut self,
         input_index: usize,
@@ -80,6 +82,7 @@ impl Psbt {
         Ok(())
     }
 
+    /// Set the full previous transaction (non-witness UTXO) for the given input.
     pub fn update_input_with_non_witness_utxo(
         &mut self,
         input_index: usize,
@@ -92,6 +95,7 @@ impl Psbt {
         Ok(())
     }
 
+    /// Set the sighash type for the given input.
     pub fn update_input_with_sighash_type(
         &mut self,
         input_index: usize,
@@ -104,6 +108,7 @@ impl Psbt {
         Ok(())
     }
 
+    /// Append a BIP-32 derivation path entry to the given input.
     pub fn update_input_with_bip32_derivation(
         &mut self,
         input_index: usize,
@@ -118,6 +123,7 @@ impl Psbt {
         Ok(())
     }
 
+    /// Append a BIP-32 derivation path entry to the given output.
     pub fn update_output_with_bip32_derivation(
         &mut self,
         output_index: usize,

--- a/src/bitcoin/types/script_buf.rs
+++ b/src/bitcoin/types/script_buf.rs
@@ -11,6 +11,7 @@ use crate::bitcoin::encoding::{
     Decodable,
 };
 
+/// A Bitcoin script stored as raw bytes.
 #[derive(Debug, Default, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ScriptBuf(pub Vec<u8>);
 
@@ -89,13 +90,6 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
                     formatter.write_str("a script hex")
                 }
 
-                // fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                // where
-                //     E: serde::de::Error,
-                // {
-                //     Ok(ScriptBuf::from_hex(v).unwrap())
-                // }
-
                 fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                 where
                     E: serde::de::Error,
@@ -118,7 +112,6 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
                     Ok(ScriptBuf(vec))
                 }
             }
-            // deserializer.deserialize_str(Visitor)
             deserializer.deserialize_any(Visitor)
         } else {
             struct BytesVisitor;

--- a/src/bitcoin/types/sighash.rs
+++ b/src/bitcoin/types/sighash.rs
@@ -1,6 +1,9 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
+/// The type of signature hash to compute.
+///
+/// Currently only [`All`](Self::All) is supported.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]

--- a/src/bitcoin/types/transaction_type.rs
+++ b/src/bitcoin/types/transaction_type.rs
@@ -1,3 +1,4 @@
+/// The spending type of a Bitcoin transaction input.
 pub enum TransactionType {
     /// Pay to public key hash
     P2PKH,

--- a/src/bitcoin/types/tx_in/hash.rs
+++ b/src/bitcoin/types/tx_in/hash.rs
@@ -11,6 +11,7 @@ use crate::bitcoin::encoding::{
     Decodable,
 };
 
+/// A 32-byte double-SHA256 hash stored in internal byte order (reversed from display).
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]

--- a/src/bitcoin/types/tx_in/tx_id.rs
+++ b/src/bitcoin/types/tx_in/tx_id.rs
@@ -9,6 +9,7 @@ use super::hash::Hash;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
+/// A Bitcoin transaction identifier (double-SHA256 of the non-witness serialization).
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]

--- a/src/evm/evm_transaction.rs
+++ b/src/evm/evm_transaction.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::{string::ToString, vec, vec::Vec};
 
+/// An EIP-1559 (type-2) transaction ready for RLP encoding and signing.
 ///
 /// ###### Example:
 ///
@@ -62,6 +63,9 @@ pub struct EVMTransaction {
 }
 
 impl EVMTransaction {
+    /// RLP-encode the unsigned EIP-1559 payload (`0x02 || RLP(fields)`) for signing.
+    ///
+    /// The caller should Keccak256-hash the result before passing it to the signer.
     pub fn build_for_signing(&self) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -76,6 +80,9 @@ impl EVMTransaction {
         rlp_stream.out().to_vec()
     }
 
+    /// RLP-encode the signed transaction (`0x02 || RLP(fields, v, r, s)`) for broadcast.
+    ///
+    /// The resulting bytes can be sent directly to an Ethereum JSON-RPC `eth_sendRawTransaction` endpoint.
     pub fn build_with_signature(&self, signature: &Signature) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
 
@@ -127,6 +134,15 @@ impl EVMTransaction {
         }
     }
 
+    /// Parse an Ethereum JSON-RPC style transaction object.
+    ///
+    /// Accepts hex-prefixed (`0x...`) and decimal string values for numeric fields.
+    /// Set `to` to `"0x"` or omit it for contract creation. The `accessList` field
+    /// is parsed if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required fields are missing or contain invalid values.
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let v: serde_json::Value = serde_json::from_str(json)?;
 

--- a/src/evm/evm_transaction_builder.rs
+++ b/src/evm/evm_transaction_builder.rs
@@ -28,6 +28,10 @@ impl Default for EVMTransactionBuilder {
 
 impl TxBuilder<EVMTransaction> for EVMTransactionBuilder {
     /// Ensures mandatory fields are set and returns an [`EVMTransaction`] ready for encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chain_id`, `nonce`, `gas_limit`, or `max_fee_per_gas` have not been set.
     fn build(&self) -> EVMTransaction {
         EVMTransaction {
             chain_id: self.chain_id.expect("chain_id is mandatory"),
@@ -107,7 +111,7 @@ impl EVMTransactionBuilder {
         self
     }
 
-    /// Provides the full access list for typed transactions; defaults to empty.
+    /// Sets the EIP-2930 access list; defaults to empty.
     pub fn access_list(mut self, access_list: AccessList) -> Self {
         self.access_list = Some(access_list);
         self

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -4,7 +4,7 @@ mod evm_transaction_builder;
 pub mod types;
 pub mod utils;
 
-/// EVM transaction
+/// EIP-1559 transaction — use [`EVMTransactionBuilder`] for ergonomic construction.
 pub use evm_transaction::EVMTransaction;
-/// EVM transaction builder
+/// Fluent builder for [`EVMTransaction`] values.
 pub use evm_transaction_builder::EVMTransactionBuilder;

--- a/src/evm/types.rs
+++ b/src/evm/types.rs
@@ -8,10 +8,13 @@ pub type Address = [u8; 20];
 /// Access list entries represented as `(address, storage_keys)` tuples.
 pub type AccessList = Vec<(Address, Vec<[u8; 32]>)>;
 
-/// EVM signature payload compatible with signing providers and RLP assembly.
+/// ECDSA signature components used to assemble a signed EIP-1559 transaction.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Signature {
+    /// Recovery ID (0 or 1 for EIP-1559).
     pub v: u64,
+    /// 32-byte big-endian R scalar.
     pub r: Vec<u8>,
+    /// 32-byte big-endian S scalar.
     pub s: Vec<u8>,
 }

--- a/src/evm/utils.rs
+++ b/src/evm/utils.rs
@@ -1,9 +1,13 @@
-//! Utility functions for serialization and encoding of EVM data structures
+//! Address parsing utilities for EVM transactions.
 use hex;
 
 use super::types::Address;
 
 /// Parse a 40-character hex address (no `0x` prefix) into a fixed array, panic on invalid input.
+///
+/// # Panics
+///
+/// Panics if the hex string is not exactly 40 characters or contains invalid hex.
 pub fn parse_eth_address(address: &str) -> Address {
     let address = hex::decode(address).expect("address should be hex");
     assert_eq!(address.len(), 20, "address should be 20 bytes long");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ mod transaction_builder;
 mod transaction_builders;
 
 pub use transaction_builder::{TransactionBuilder, TxBuilder};
-/// Alias for BitcoinTransactionBuilder
+/// Builder alias for Bitcoin transactions — use via [`TransactionBuilder::new::<BITCOIN>()`].
 #[cfg(feature = "bitcoin")]
 pub use transaction_builders::BITCOIN;
-/// Alias for EVMTransactionBuilder
+/// Builder alias for EVM transactions — use via [`TransactionBuilder::new::<EVM>()`].
 #[cfg(feature = "evm")]
 pub use transaction_builders::EVM;

--- a/src/signer/types.rs
+++ b/src/signer/types.rs
@@ -25,7 +25,10 @@ pub struct SerializableScalar {
 /// Request sent to a signing service describing what and where to sign.
 #[derive(Debug, Serialize)]
 pub struct SignRequest {
+    /// The 32-byte hash to be signed (e.g., Keccak256 of an EVM tx or SHA256d of a BTC sighash).
     pub payload: [u8; 32],
+    /// Derivation path identifying which key to use (e.g., `"m/44'/60'/0'/0/0"`).
     pub path: String,
+    /// Version of the signing key to use.
     pub key_version: u32,
 }

--- a/src/transaction_builder.rs
+++ b/src/transaction_builder.rs
@@ -11,8 +11,8 @@ pub trait TxBuilder<T> {
 pub struct TransactionBuilder;
 
 impl TransactionBuilder {
-    #[allow(clippy::new_ret_no_self)]
     /// Materializes the default builder for the requested chain so callers can begin configuring it.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<T>() -> T
     where
         T: Default,

--- a/src/transaction_builders.rs
+++ b/src/transaction_builders.rs
@@ -1,4 +1,4 @@
-//! Low level transaction builders for different blockchains.
+//! Convenience type aliases for chain-specific transaction builders.
 #[cfg(feature = "bitcoin")]
 use crate::bitcoin::BitcoinTransactionBuilder;
 


### PR DESCRIPTION
## Summary
- Add struct/method doc comments to all public API surface (EVMTransaction, BitcoinTransaction, PSBT, signer types)
- Add `# Panics` sections to every method that can panic
- Document core types: Hash, Txid, ScriptBuf, EcdsaSighashType, TransactionType
- Fix Cargo.toml: description, keywords, categories
- Fix README Bitcoin example (ScriptBuf was storing ASCII bytes instead of decoded script)
- Fix CHANGELOG categories
- Remove dead code from script_buf.rs

## Test plan
- [x] `cargo test --all-features` — 104 tests pass
- [x] `cargo clippy --all-targets -- -D clippy::all -D clippy::nursery` — clean
- [x] `cargo fmt --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` — clean