### PR TITLE
Release v1.0.1

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-plz:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.3] - 2025-11-07
+## [1.0.1] - 2026-03-28
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signet-rs"
-version = "0.0.3"
+version = "1.0.1"
 authors = ["Sig Network", "Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-signet-rs = "0.0.3"
+signet-rs = "1.0.1"
 ```
 
 ## Features


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 (crates.io already has 1.0.0, so we can't use 0.0.3)
- Fix release-plz workflow: trigger on `main` instead of `master`
- Update CHANGELOG version and date

Once merged, release-plz will automatically publish to crates.io (requires `CARGO_REGISTRY_TOKEN` and `RELEASE_PLZ_GITHUB_TOKEN` secrets to be configured).

## Changes since 1.0.0
- Fix critical BIP-143 sighash bug (marker/flag in preimage)
- Fix legacy sighash to use non-witness serialization
- Fix `from_json` defects (contract creation, access list parsing, panic→Result)
- Fix `deserialize_address` silent truncation, hex support in serde path
- Add 30 new tests (70 → 100) validated against Alloy and rust-bitcoin
- Comprehensive documentation across all public API
- Simplify CI (15 → 11 jobs)